### PR TITLE
Fix: make unused fields optional

### DIFF
--- a/pytcs_tecnoalarm/api_models.py
+++ b/pytcs_tecnoalarm/api_models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from pydantic import BaseModel, RootModel, Field, model_validator, field_validator, computed_field
+from typing import Optional
 
 # from tcsession import Centrale
 
@@ -37,7 +38,7 @@ class TcsMonitor(BaseModel):
 
 
 class TcsTpstatusObject(BaseModel):
-    description: str
+    description: Optional[str] = ""
     icon: str
     idx: int
 

--- a/pytcs_tecnoalarm/objects.py
+++ b/pytcs_tecnoalarm/objects.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from typing import Optional
 
 
 class HandshakeEntrypoint(BaseModel):
@@ -11,13 +12,14 @@ class HandshakeEntrypoint(BaseModel):
 
 class HandshakeAccount(BaseModel):
     accountId: int
-    backupDate: int
-    features: list
-    lastLogin: int
-    subscriptionDate: int
+    backupDate: Optional[int] = None
+    features: Optional[list] = Field(default=None)
+    lastLogin: Optional[int] = None
+    subscriptionDate: Optional[int] = None
 
 
 class HandshakeAnswer(BaseModel):
     appID: int
     entrypoints: list[HandshakeEntrypoint]
     account: HandshakeAccount | None
+


### PR DESCRIPTION
API does not always return all fields, causing ValidationError. Made features and other unused fields optional for robustness.